### PR TITLE
⬆️ 🤖 - Many pages make a thick book except for pocket Bibles which are on very

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ tradingeconomics = "^4.3.12"
 
 [tool.poetry.group.dev.dependencies]
 python-semantic-release = ">=8.0.8"
-ruff = "^0.9.0"
+ruff = "^0.10.0"
 pre-commit = "^4.0.0"
 
 


### PR DESCRIPTION
Auto Release

## Summary by Sourcery

Chores:
- Update ruff dependency to version 0.10.0.