### PR TITLE
🚀 new version build(deps): convertion to uv

### DIFF
--- a/.github/.pre-commit-config.yaml
+++ b/.github/.pre-commit-config.yaml
@@ -1,18 +1,37 @@
+# repos:
+#   - repo: https://github.com/astral-sh/ruff-pre-commit
+#     rev: v0.0.292
+#     hooks:
+#      - id: ruff
+#        args: [--fix, --exit-non-zero-on-fix]
+
+#   - repo: https://github.com/pre-commit/pre-commit-hooks
+#     rev: v4.4.0
+#     hooks:
+#       - id: check-merge-conflict
+#       - id: trailing-whitespace
+
+#   - repo: https://github.com/PyCQA/bandit
+#     rev: '1.7.5'
+#     hooks:
+#     - id: bandit
+#       args: ["-c", "pyproject.toml"]
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.292
+    rev: v0.11.7
     hooks:
      - id: ruff
        args: [--fix, --exit-non-zero-on-fix]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: trailing-whitespace
 
   - repo: https://github.com/PyCQA/bandit
-    rev: '1.7.5'
+    rev: '1.8.3'
     hooks:
     - id: bandit
       args: ["-c", "pyproject.toml"]

--- a/.github/workflows/👷Flow.yml
+++ b/.github/workflows/👷Flow.yml
@@ -7,21 +7,24 @@ on:
   workflow_dispatch:
   merge_group:
 
-
 jobs:
   lint:
-    uses: mraniki/coding_toolset/.github/workflows/🦺Lint.yml@main
+    # uses: mraniki/coding_toolset/.github/workflows/🦺Lint.yml@main
+    uses: mraniki/coding_toolset/.github/workflows/UVLint.yml@main
     secrets: inherit
   test:
     needs: [lint]
-    uses: mraniki/coding_toolset/.github/workflows/🧪Test.yml@main
+    # uses: mraniki/coding_toolset/.github/workflows/🧪Test.yml@main
+    uses: mraniki/coding_toolset/.github/workflows/UVTest.yml@main
     secrets: inherit
   build:
     needs: [lint]
-    uses: mraniki/coding_toolset/.github/workflows/🐍Build.yml@main
+    # uses: mraniki/coding_toolset/.github/workflows/🐍Build.yml@main
+    uses: mraniki/coding_toolset/.github/workflows/UVBuild.yml@main
     secrets: inherit
   release:
     needs: [build, test]
-    uses: mraniki/coding_toolset/.github/workflows/📦Release.yml@main
+    # uses: mraniki/coding_toolset/.github/workflows/📦Release.yml@main
+    uses: mraniki/coding_toolset/.github/workflows/UVRelease.yml@main # Use UV-specific release workflow
     secrets: inherit
 

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -4,11 +4,15 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.11"
+    # uv is not directly supported in tools, install via pip below
+    # uv: "latest"
   jobs:
+    # Install uv after the environment is created
     post_create_environment:
-      - python -m pip install poetry
+      - pip install uv
     post_install:
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH python -m poetry install --with docs
+      # Install the package with docs extras using uv
+      - uv pip install -e '.[docs]'
 
 sphinx:
   configuration: docs/conf.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,49 +1,74 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
 
-
-[tool.poetry]
+[project]
 name = "iamlistening"
 version = "5.3.42"
 description = "A python package to interact with messaging platform."
-authors = ["mraniki <8766259+mraniki@users.noreply.github.com>"]
-license = "MIT License"
+authors = [
+  { name = "mraniki", email = "8766259+mraniki@users.noreply.github.com" },
+]
+license = "MIT"
 readme = "README.md"
 keywords = [
     "bot","messaging",
     "discord", "telegram","matrix",
     ]
-packages = [
-    {include = "iamlistening"}
+requires-python = ">=3.10,<3.12"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+]
+dependencies = [
+  "dynaconf>=3.1.12",
+  "loguru>=0.6.0",
+  "telethon==1.40.0",
+  "py-cord==2.6.1",
+  "simplematrixbotlib==2.10.3",
+  "rocketchat-API==1.35.0",
+  "Mastodon.py==2.0.1",
+  "beautifulsoup4==4.13.4",
+  "guilded.py==1.13.2",
+  "revolt.py==0.2.0",
+  'pythorhead==0.32.1; python_version >= "3.10" and python_version < "3.12"',
+  "twitchio==2.10.0",
+  "tradingeconomics>=4.3.12",
 ]
 
-[tool.poetry.urls]
+
+[project.urls]
+"Homepage" = "https://github.com/mraniki/iamlistening"
 "Changelog" =  "https://github.com/mraniki/iamlistening/blob/dev/CHANGELOG.rst"
 "Support" =  "https://github.com/mraniki/iamlistening/discussions"
 "Issues" =  "https://github.com/mraniki/iamlistening/issues"
 
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
 
-[tool.poetry.dependencies]
-python = ">=3.10,<3.12"
-dynaconf = ">=3.1.12"
-loguru = ">=0.6.0"
-telethon= "1.40.0"
-py-cord= "2.6.1"
-simplematrixbotlib= "2.10.3"
-rocketchat-API= "1.35.0"
-"Mastodon.py" = "2.0.1"
-beautifulsoup4 = "4.13.4"
-"guilded.py" = "1.13.2"
-"revolt.py" = "0.2.0"
-pythorhead = {version ="0.32.1", python = ">=3.10,<3.12"}
-twitchio = "2.10.0"
-tradingeconomics = "^4.3.12"
+[project.optional-dependencies]
+dev = [
+  "python-semantic-release>=8.0.8",
+  "ruff~=0.11",
+  "pre-commit~=4.0",
+]
+test = [
+  "pytest~=8.0",
+  "pytest-cov~=6.0",
+  "pytest-asyncio~=0.26",
+  "pytest-mock~=3.11",
+  "pytest-loguru~=0.4",
+]
+docs = [
+  "sphinx==7.4.7",
+  "pydata-sphinx-theme~=0.14",
+  "sphinx-hoverxref~=1.3",
+  "sphinx_copybutton==0.5.2",
+  "myst_parser~=4.0",
+  "sphinx_design~=0.6",
+]
 
-[tool.poetry.group.dev.dependencies]
-python-semantic-release = ">=8.0.8"
-ruff = "^0.11.0"
-pre-commit = "^4.0.0"
+[tool.setuptools]
+packages = ["iamlistening"]
 
 
 [tool.ruff]
@@ -54,17 +79,15 @@ exclude = [
 
 [tool.ruff.lint]
 select = [
-  "E",  # pycodestyle
-  "F",  # pyflakes
-  "I",  # isort
+  "E",
+  "F",
+  "I",
   "W"
 ]
 
-#ignore = ["E401","F401","F811"]
 fixable = ["ALL"]
 
 [tool.ruff.format]
-# Like Black, use double quotes for strings.
 quote-style = "double"
 
 
@@ -75,259 +98,12 @@ overgeneral-exceptions = [
     "builtins.RuntimeError",
 ]
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-[tool.poetry.group.test.dependencies]
-pytest = "^8.0.0"
-pytest-cov = "^6.0.0"
-pytest-asyncio = "^0.26.0"
-pytest-mock = "^3.11.1"
-pytest-loguru = "^0.4.0"
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-[tool.poetry.group.docs]
-optional = true
-
-[tool.poetry.group.docs.dependencies]
-sphinx = "7.4.7"
-pydata-sphinx-theme = "^0.16.0"
-sphinx-hoverxref = "^1.3.0"
-sphinx_copybutton = "0.5.2"
-myst_parser = "^4.0.0"
-sphinx_design = "^0.6.0"
-
-
 [tool.pytest.ini_options]
 pythonpath = "."
 testpaths = "tests"
 python_classes = "Test*"
 log_format = "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
 log_level = "DEBUG"
-filterwarnings = [
-    " ignore:.*U.*mode is deprecated:DeprecationWarning",
-    "ignore::DeprecationWarning",
-]
 addopts = """
 -v
 --show-capture=stderr
@@ -341,7 +117,7 @@ omit = [
     "docs/*",
     "*/config.py"
 ]
-
+ 
 [tool.bandit]
 exclude_dirs = ["tests","docs"]
 skips = ["B101","B104"]
@@ -349,12 +125,10 @@ skips = ["B101","B104"]
 [tool.semantic_release]
 upload_to_vcs_release = true
 version_variables = ["iamlistening/__init__.py:__version__"]
-build_command = "pip install poetry && poetry build"
 commit_parser = "emoji"
 version_toml = [
-   "pyproject.toml:tool.poetry.version",
+   "pyproject.toml:project.version",
    ]
-
 
 [tool.semantic_release.commit_parser_options]
 major_tags = [
@@ -392,11 +166,10 @@ patch_tags = ["fix","bump","Update",
     "⚗️",":alembic:",
     "🧐",":monocle_face:",
     "🔇",":mute:",
-    "🔊",":loud:",
+    "🔊",":volume:",
 ]
 
 [tool.semantic_release.changelog]
-# template_dir = "templates"
 changelog_file = "CHANGELOG.md"
 exclude_commit_patterns = []
 


### PR DESCRIPTION
## Summary by Sourcery

Migrate project packaging from Poetry to Setuptools/PEP 621 and adopt UV for dependency management.

Build:
- Replace Poetry configuration with PEP 621 `[project]` and `[build-system]` tables in `pyproject.toml`.
- Update semantic release configuration to align with Setuptools.
- Update pre-commit hook dependencies (`ruff`, `pre-commit-hooks`, `bandit`) to newer versions.
- Remove filterwarnings configuration from pytest settings.
- Specify package discovery using `tool.setuptools` configuration.
- Update project metadata including license format and URLs to conform to PEP 621 standards.
- Consolidate main, development, test, and documentation dependencies under PEP 621 standard sections (`dependencies` and `optional-dependencies`).

CI:
- Update the ReadTheDocs build workflow to use `uv` for dependency installation.